### PR TITLE
Use is_alive instead of isAlive for Python 3.9 compatibility.

### DIFF
--- a/mom/RPCServer.py
+++ b/mom/RPCServer.py
@@ -59,7 +59,7 @@ class RPCServer(threading.Thread):
     def thread_ok(self):
         if self.server is None:
             return True
-        return self.isAlive()
+        return self.is_alive()
 
     def create_server(self):
         try:

--- a/mom/__init__.py
+++ b/mom/__init__.py
@@ -213,7 +213,7 @@ class MOM:
         Check to make sure a list of expected threads are still alive
         """
         for t in threads:
-            if not t.isAlive():
+            if not t.is_alive():
                 self.logger.error("Thread '%s' has exited" % t.getName())
                 return False
         return True
@@ -222,7 +222,7 @@ class MOM:
         """
         Join a thread only if it is still running
         """
-        if t.isAlive():
+        if t.is_alive():
             t.join(timeout)
 
     def get_hypervisor_interface(self):

--- a/tests/GeneralTests.py
+++ b/tests/GeneralTests.py
@@ -44,7 +44,7 @@ def start_mom(config=None):
     t.setDaemon(True)
     t.start()
     while True:
-        if not t.isAlive():
+        if not t.is_alive():
             return None
         try:
             mom_instance.setVerbosity('critical')


### PR DESCRIPTION
Fixes Python 3.9 compatibility reported in https://bugzilla.redhat.com/show_bug.cgi?id=1791976