### PR TITLE
use ConfigParser instead of SafeConfigParser

### DIFF
--- a/mom/__init__.py
+++ b/mom/__init__.py
@@ -93,7 +93,7 @@ class MOM:
                 setattr(self, funcName, funcObj)
 
     def _load_config(self, fname, overrides):
-        self.config = configparser.SafeConfigParser()
+        self.config = configparser.ConfigParser()
 
         # Set built-in defaults
         self.config.add_section('main')

--- a/momd.in
+++ b/momd.in
@@ -79,7 +79,7 @@ def signal_quit(signum, frame):
     mom_instance.shutdown()
 
 def get_option_overrides(options):
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.add_section('main')
     config.add_section('logging')
     if options.plot_dir is not None:

--- a/tests/GeneralTests.py
+++ b/tests/GeneralTests.py
@@ -35,7 +35,7 @@ from six.moves import xmlrpc_client
 
 def start_mom(config=None):
     if not config:
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config.add_section('logging')
         config.set('logging', 'verbosity', 'error')
 
@@ -106,7 +106,7 @@ class ConfigTests(TestCaseBase):
                 f.write(policy)
 
 
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config.add_section('main')
         config.set('main', 'policy-dir', policy_dir)
         config.add_section('logging')


### PR DESCRIPTION
The SafeConfigParser class has been renamed to ConfigParser in Python 3.2.
This alias will be removed in future versions. Using ConfigParser directly instead.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=2001789
Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>