### PR TITLE
Fix deprecation warnings for Python 3 compatibility.

### DIFF
--- a/mom/GuestManager.py
+++ b/mom/GuestManager.py
@@ -41,7 +41,7 @@ class GuestManager(threading.Thread):
     """
     def __init__(self, config, hypervisor_iface):
         threading.Thread.__init__(self, name='GuestManager')
-        self.setDaemon(True)
+        self.daemon = True
         self.config = config
         self.hypervisor_iface = hypervisor_iface
         self.logger = logging.getLogger('mom.GuestManager')

--- a/mom/GuestMonitor.py
+++ b/mom/GuestMonitor.py
@@ -62,18 +62,18 @@ class GuestMonitorThread(threading.Thread):
             name = name.encode('utf-8')
 
         self.setName(name)
-        self.setDaemon(True)
+        self.daemon = True
         self.logger = logging.getLogger('mom.GuestMonitor.Thread')
 
         self._mon = monitor
 
     def run(self):
         try:
-            self.logger.info("%s starting", self.getName())
+            self.logger.info("%s starting", self.name)
             while self._mon.should_run():
                 self._mon.collect()
                 time.sleep(self._mon.interval)
         except Exception:
-            self.logger.exception("%s crashed", self.getName())
+            self.logger.exception("%s crashed", self.name)
         else:
-            self.logger.info("%s ending", self.getName())
+            self.logger.info("%s ending", self.name)

--- a/mom/HostMonitor.py
+++ b/mom/HostMonitor.py
@@ -26,8 +26,8 @@ class HostMonitor(Monitor, threading.Thread):
     """
     def __init__(self, config):
         threading.Thread.__init__(self, name="HostMonitor")
-        Monitor.__init__(self, config, self.getName())
-        self.setDaemon(True)
+        Monitor.__init__(self, config, self.name)
+        self.daemon = True
         self.config = config
         self.logger = logging.getLogger('mom.HostMonitor')
         self.interval = self.config.getint('main', 'host-monitor-interval')

--- a/mom/PolicyEngine.py
+++ b/mom/PolicyEngine.py
@@ -29,7 +29,7 @@ class PolicyEngine(threading.Thread):
     """
     def __init__(self, config, hypervisor_iface, host_monitor, guest_manager):
         threading.Thread.__init__(self, name="PolicyEngine")
-        self.setDaemon(True)
+        self.daemon = True
         self.config = config
         self.logger = logging.getLogger('mom.PolicyEngine')
         self.properties = {

--- a/mom/RPCServer.py
+++ b/mom/RPCServer.py
@@ -49,7 +49,7 @@ class RPCServer(threading.Thread):
     """
     def __init__(self, config, momFuncs):
         threading.Thread.__init__(self, name="RPCServer")
-        self.setDaemon(True)
+        self.daemon = True
         self.config = config
         self.momFuncs = momFuncs
         self.logger = logging.getLogger('mom.RPCServer')

--- a/mom/__init__.py
+++ b/mom/__init__.py
@@ -214,7 +214,7 @@ class MOM:
         """
         for t in threads:
             if not t.is_alive():
-                self.logger.error("Thread '%s' has exited" % t.getName())
+                self.logger.error("Thread '%s' has exited" % t.name)
                 return False
         return True
 

--- a/tests/GeneralTests.py
+++ b/tests/GeneralTests.py
@@ -41,7 +41,7 @@ def start_mom(config=None):
 
     mom_instance = mom.MOM("", config)
     t = threading.Thread(target=mom_instance.run)
-    t.setDaemon(True)
+    t.daemon = True
     t.start()
     while True:
         if not t.is_alive():
@@ -68,27 +68,27 @@ class GeneralTests(TestCaseBase):
         self.assertTrue(isinstance(self.mom_instance.getActiveGuests(),
                                      list))
     def testPolicyAPI(self):
-        self.assertEquals('0', self.mom_instance.getPolicy())
+        self.assertEqual('0', self.mom_instance.getPolicy())
 
         badPolicy = "("
         self.assertFalse(self.mom_instance.setPolicy(badPolicy))
-        self.assertEquals('0', self.mom_instance.getPolicy())
+        self.assertEqual('0', self.mom_instance.getPolicy())
 
         goodPolicy = "(+ 1 1)"
         self.assertTrue(self.mom_instance.setPolicy(goodPolicy))
-        self.assertEquals(goodPolicy, self.mom_instance.getPolicy())
+        self.assertEqual(goodPolicy, self.mom_instance.getPolicy())
 
         self.assertTrue(self.mom_instance.setPolicy(None))
-        self.assertEquals('0', self.mom_instance.getPolicy())
+        self.assertEqual('0', self.mom_instance.getPolicy())
 
     def testMultiplePolicies(self):
-        self.assertEquals(0, len(list(self.mom_instance.getNamedPolicies().keys())))
+        self.assertEqual(0, len(list(self.mom_instance.getNamedPolicies().keys())))
 
         self.mom_instance.setNamedPolicy("10_test", "(+ 1 1)")
         self.mom_instance.setNamedPolicy("20_test", "(- 1 1)")
         policies = self.mom_instance.getNamedPolicies()
-        self.assertEquals("(+ 1 1)", policies["10_test"])
-        self.assertEquals("(- 1 1)", policies["20_test"])
+        self.assertEqual("(+ 1 1)", policies["10_test"])
+        self.assertEqual("(- 1 1)", policies["20_test"])
 
         self.mom_instance.setNamedPolicy("20_test", None)
         policies = self.mom_instance.getNamedPolicies()
@@ -115,15 +115,15 @@ class ConfigTests(TestCaseBase):
 
         try:
             policies = mom_instance.getNamedPolicies()
-            self.assertEquals('(+ 1 1)', policies['01_foo'])
-            self.assertEquals('(- 2 1)', policies['02_bar'])
+            self.assertEqual('(+ 1 1)', policies['01_foo'])
+            self.assertEqual('(- 2 1)', policies['02_bar'])
 
             mom_instance.setNamedPolicy('02_bar', None)
             mom_instance.setNamedPolicy('03_baz', '(/ 10 5)')
-            self.assertEquals("(+ 1 1)\n(/ 10 5)", mom_instance.getPolicy())
+            self.assertEqual("(+ 1 1)\n(/ 10 5)", mom_instance.getPolicy())
             mom_instance.resetPolicies()
-            self.assertEquals('(+ 1 1)', policies['01_foo'])
-            self.assertEquals('(- 2 1)', policies['02_bar'])
+            self.assertEqual('(+ 1 1)', policies['01_foo'])
+            self.assertEqual('(- 2 1)', policies['02_bar'])
             self.assertTrue('03_baz' not in iter(policies.keys()))
         finally:
             shutil.rmtree(policy_dir)


### PR DESCRIPTION
* `assertEquals` is deprecated. Use `assertEqual` instead in tests.
* Set `daemon` attribute directly in favor of `setDaemon`.
* Use `name` attribute directly instead of `getName`.

The above changes are compatible with Python 2 too.

Fixes #8 