### PR TITLE
Increase cache expiration time for IO tune

### DIFF
--- a/mom/HypervisorInterfaces/vdsmjsonrpcInterface.py
+++ b/mom/HypervisorInterfaces/vdsmjsonrpcInterface.py
@@ -25,7 +25,8 @@ from .vdsmRpcBase import VdsmRpcBase
 from mom.optional import Optional
 
 # Time validity of the cache in seconds
-CACHE_EXPIRATION = 5
+CACHE_EXPIRATION_IOTUNE = 300
+CACHE_EXPIRATION_STATS = 5
 
 
 class JsonRpcVdsmInterface(VdsmRpcBase):
@@ -53,7 +54,7 @@ class JsonRpcVdsmInterface(VdsmRpcBase):
             pass
 
 
-    @memoize(expiration=CACHE_EXPIRATION)
+    @memoize(expiration=CACHE_EXPIRATION_STATS)
     def getAllVmStats(self):
         vms = {}
         ret = self.checked_call(self._vdsm_api.getAllVmStats)

--- a/mom/HypervisorInterfaces/vdsmjsonrpcbulkInterface.py
+++ b/mom/HypervisorInterfaces/vdsmjsonrpcbulkInterface.py
@@ -17,7 +17,7 @@
 from .vdsmCommon import memoize
 
 from mom.HypervisorInterfaces.vdsmjsonrpcInterface import JsonRpcVdsmInterface, \
-    CACHE_EXPIRATION
+    CACHE_EXPIRATION_IOTUNE
 
 class JsonRpcVdsmBulkInterface(JsonRpcVdsmInterface):
     """
@@ -28,7 +28,7 @@ class JsonRpcVdsmBulkInterface(JsonRpcVdsmInterface):
     def __init__(self):
         super(JsonRpcVdsmBulkInterface, self).__init__()
 
-    @memoize(expiration=CACHE_EXPIRATION)
+    @memoize(expiration=CACHE_EXPIRATION_IOTUNE)
     def getAllVmIoTunePolicies(self):
         ret = self.checked_call(self._vdsm_api.getAllVmIoTunePolicies)
         return ret

--- a/mom/HypervisorInterfaces/vdsmjsonrpcclientInterface.py
+++ b/mom/HypervisorInterfaces/vdsmjsonrpcclientInterface.py
@@ -24,7 +24,8 @@ from .vdsmRpcBase import VdsmRpcBase
 from mom.optional import Optional
 
 # Time validity of the cache in seconds
-CACHE_EXPIRATION = 5
+CACHE_EXPIRATION_IOTUNE = 300
+CACHE_EXPIRATION_STATS = 5
 
 
 class JsonRpcVdsmClientInterface(VdsmRpcBase):
@@ -44,12 +45,12 @@ class JsonRpcVdsmClientInterface(VdsmRpcBase):
 
         self.checked_call(self._vdsm_api.Host.ping2)
 
-    @memoize(expiration=CACHE_EXPIRATION)
+    @memoize(expiration=CACHE_EXPIRATION_STATS)
     def getAllVmStats(self):
         ret = self.checked_call(self._vdsm_api.Host.getAllVmStats)
         return {vm['vmId']: vm for vm in ret}
 
-    @memoize(expiration=CACHE_EXPIRATION)
+    @memoize(expiration=CACHE_EXPIRATION_IOTUNE)
     def getAllVmIoTunePolicies(self):
         return self.checked_call(self._vdsm_api.Host.getAllVmIoTunePolicies)
 

--- a/mom/HypervisorInterfaces/vdsmxmlrpcInterface.py
+++ b/mom/HypervisorInterfaces/vdsmxmlrpcInterface.py
@@ -22,7 +22,8 @@ from .vdsmCommon import memoize, vdsmException
 from .vdsmRpcBase import VdsmRpcBase
 
 # Time validity of the cache in seconds
-CACHE_EXPIRATION = 5
+CACHE_EXPIRATION_IOTUNE = 300
+CACHE_EXPIRATION_STATS = 5
 
 
 class XmlRpcVdsmInterface(VdsmRpcBase):
@@ -48,7 +49,7 @@ class XmlRpcVdsmInterface(VdsmRpcBase):
         if response['status']['code']:
             raise vdsmException(response, self._logger)
 
-    @memoize(expiration=CACHE_EXPIRATION)
+    @memoize(expiration=CACHE_EXPIRATION_STATS)
     def getAllVmStats(self):
         vms = {}
 

--- a/mom/HypervisorInterfaces/vdsmxmlrpcbulkInterface.py
+++ b/mom/HypervisorInterfaces/vdsmxmlrpcbulkInterface.py
@@ -17,7 +17,7 @@
 from .vdsmCommon import memoize
 
 from mom.HypervisorInterfaces.vdsmxmlrpcInterface import XmlRpcVdsmInterface, \
-    CACHE_EXPIRATION
+    CACHE_EXPIRATION_IOTUNE
 
 from mom.optional import Optional
 
@@ -31,7 +31,7 @@ class XmlRpcVdsmBulkInterface(XmlRpcVdsmInterface):
     def __init__(self):
         super(XmlRpcVdsmBulkInterface, self).__init__()
 
-    @memoize(expiration=CACHE_EXPIRATION)
+    @memoize(expiration=CACHE_EXPIRATION_IOTUNE)
     def getAllVmIoTunePolicies(self):
         try:
             ret = self.vdsm_api.getAllVmIoTunePolicies()


### PR DESCRIPTION
Separate expiration time for VM stats cache from block IO tune
parameters cache and increase block IO tune parameters cache expiration
to 5 minutes. It is not expected for the parameters to change too often
so no need to bother VDSM too much. It also significantly decreases the
unnecessary traffic in log files on VDSM site.

Bug-Url: https://bugzilla.redhat.com/1720976
Signed-off-by: Tomáš Golembiovský <tgolembi@redhat.com>