### PR TITLE
Fill default value for guest-manager-multi-thread in example conf files

### DIFF
--- a/doc/mom-balloon+ksm.conf
+++ b/doc/mom-balloon+ksm.conf
@@ -61,7 +61,7 @@ policy-dir:
 # advantage of those guarantees, and do the monitoring using a single thread.
 # If set to false, disable the current behaviour and configure MOM to monitor
 # all the VMs using only one thread.
-guest-manager-multi-thread:
+guest-manager-multi-thread: true
 
 [logging]
 # Set the destination for program log messages.  This can be either 'stdio' or

--- a/doc/mom-balloon.conf
+++ b/doc/mom-balloon.conf
@@ -61,7 +61,7 @@ policy-dir:
 # advantage of those guarantees, and do the monitoring using a single thread.
 # If set to false, disable the current behaviour and configure MOM to monitor
 # all the VMs using only one thread.
-guest-manager-multi-thread:
+guest-manager-multi-thread: true
 
 [logging]
 # Set the destination for program log messages.  This can be either 'stdio' or


### PR DESCRIPTION
Value of guest-manager-multi-thread is empty in example conf files, which will cause momd service failed to start with default conf file.
Set default value of guest-manager-multi-thread to true according to annotations in example conf files.