### PR TITLE
automation: use latest oVirt actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         distro: [el8stream, el9stream]
     steps:
-      - uses: actions/checkout@v2
+      - uses: ovirt/checkout-action@main
         with:
           fetch-depth: 0
       - name: Mark repository as safe
@@ -20,7 +20,6 @@ jobs:
       - name: Check patch
         run: ./automation/check-patch.sh
       - name: Upload artifacts
-        uses: ovirt/upload-rpms-action@v1
+        uses: ovirt/upload-rpms-action@main
         with:
           directory: ${{ env.EXPORT_DIR }}
-          distro: ${{ matrix.distro }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     container: quay.io/ovirt/buildcontainer:${{ matrix.distro }}
     strategy:
       matrix:
-        distro: [el8stream, el9stream]
+        distro: [el9stream]
     steps:
       - uses: ovirt/checkout-action@main
         with:


### PR DESCRIPTION
Recently GitHub started failing on deprecated upload artifacts actions:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```