### PR TITLE
ci: allow manual ci run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 ---
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
 env:
   EXPORT_DIR: exported-artifacts
 jobs:


### PR DESCRIPTION
Add workflow_dispatch to the CI workflow to be able to manually trigger the CI workflow.
Also only run the CI for PR's and commits on master branch.